### PR TITLE
So the conjugate gradient can complete multiple iterations, and α shr…

### DIFF
--- a/production_c/Makefile_Intel
+++ b/production_c/Makefile_Intel
@@ -45,7 +45,7 @@ TMP=	$(MOD) $(EDT) core
 -include $(DEPS)
 all:	$(EXE)
 
-profiler:	CFLAGS += -g# -D_DEBUG
+profiler:	CFLAGS += -g -D_DEBUG
 profiler:	release
 
 release:	CFLAGS +=  -O3  -inline-level=2\

--- a/production_c/congrad.c
+++ b/production_c/congrad.c
@@ -59,7 +59,7 @@ int Congradq(int na,double res,Complex *X1,Complex *r,Complex_f *u11t_f,Complex_
 	cudaMemAdvise(p_f,kferm2Halo*sizeof(Complex_f),cudaMemAdviseSetPreferredLocation,device);
 
 	cudaMalloc(&x1_f, kferm2Halo*sizeof(Complex_f));
-	cudaMalloc(&x2_f, kferm2Halo*sizeof(Complex_f));
+	cudaMallocManaged(&x2_f, kferm2Halo*sizeof(Complex_f),cudaMemAttachGlobal);
 
 	cudaMallocManaged(&x2, kferm2*sizeof(Complex),cudaMemAttachGlobal);
 	cudaMemAdvise(x2,kferm2*sizeof(Complex),cudaMemAdviseSetPreferredLocation,device);


### PR DESCRIPTION
…inks as expected. β_n is growing rather than converging though. Is this a matrix multiplication error or a race condition?

Running inside cuda-gdb (which is synchronous) gives the same problem so _for now_ I am assuming the matrix multiplication is at fault rather than a kernel not finishing before CPU code starts running. There could be other issues at play too though such as BLAS.